### PR TITLE
Convert gen_version using culture invariant rules

### DIFF
--- a/client/APClient.cs
+++ b/client/APClient.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using ReplantedArchipelago.Patches;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace ReplantedArchipelago
@@ -100,7 +101,7 @@ namespace ReplantedArchipelago
                 var loginSuccess = (LoginSuccessful)result;
                 slotData = loginSuccess.SlotData;
 
-                genVersion = Convert.ToString(slotData["gen_version"]);
+                genVersion = ((double)slotData["gen_version"]).ToString(CultureInfo.InvariantCulture);
 
                 if (genVersion != Data.GenVersion) //Version mismatch
                 {


### PR DESCRIPTION
This PR fixes a bug where, in locales where the decimal point is a comma instead of a full stop, conversion of the version number would result in a string that did not match the expected version number.

Please consider setting `GEN_VERSION = "1.4"` in the apworld in the next release :)